### PR TITLE
dewey: expose analyzers as a golangci-lint module plugin

### DIFF
--- a/gomod2nix.toml
+++ b/gomod2nix.toml
@@ -318,6 +318,14 @@ schema = 3
     hash = 'sha256-/dGNGhn9Jvdb6D95qbN1DLfS6H7ZS4G4AubU9zUDgdU='
     goVersion = '1.18'
 
+  [mod.'github.com/golangci/plugin-module-register']
+    version = 'v0.1.2'
+    hash = 'sha256-1ynPByzfsjZtScZyxl36ARmva6rSIxIyDi6P7pQwl30='
+    goVersion = '1.23.0'
+    vendorPackages = [
+      'github.com/golangci/plugin-module-register/register'
+    ]
+
   [mod.'github.com/google/go-cmp']
     version = 'v0.7.0'
     hash = 'sha256-JbxZFBFGCh/Rj5XZ1vG94V2x7c18L8XKB0N9ZD5F2rM='

--- a/libs/dewey/CLAUDE.md
+++ b/libs/dewey/CLAUDE.md
@@ -52,6 +52,20 @@ their own locations for now. Don't move `cmd/dagnabit` in here without a
 matching issue update; the decomposition as of purse-first#45 intentionally
 kept the public tool separate from reusable primitives.
 
+## gclplugin/
+
+`libs/dewey/gclplugin/` registers the three static analyzers (`defererr`,
+`seqerror`, `repool`) as a golangci-lint **module plugin** so downstream
+repos that already gate on `golangci-lint` can fold them into that run
+instead of a separate `go vet -vettool` pass (see purse-first#120). It
+imports the stable `pkgs/analyzer_<name>.Analyzer` facades and calls
+`register.Plugin("dewey", New)`; `Settings` lets a consumer opt out per
+analyzer (all enabled by default; `repool` is a no-op outside pool-owning
+packages). This is additive — the `cmd/<name>` singlechecker + vettool
+path stays for non-golangci consumers. Consumers wire it via
+`.custom-gcl.yml` + `golangci-lint custom`; the package doc comment carries
+the full snippet.
+
 ## Testing
 
 Use `just test-dewey` from the repo root. It runs `go test -tags test

--- a/libs/dewey/gclplugin/plugin.go
+++ b/libs/dewey/gclplugin/plugin.go
@@ -1,0 +1,109 @@
+// Package gclplugin registers the dewey static analyzers as a
+// golangci-lint Module Plugin.
+//
+// It wires the three dewey go/analysis analyzers — defererr, seqerror,
+// and repool — into golangci-lint's module plugin system so a downstream
+// repo that already gates on golangci-lint can fold them into that same
+// run instead of a separate `go vet -vettool` pass.
+//
+// # Consuming the plugin
+//
+// Add the module to a .custom-gcl.yml:
+//
+//	version: v2.5.0
+//	plugins:
+//	  - module: github.com/amarbel-llc/purse-first/libs/dewey
+//	    import: github.com/amarbel-llc/purse-first/libs/dewey/gclplugin
+//	    version: latest
+//
+// Build a custom binary with `golangci-lint custom`, then enable the
+// linter in .golangci.yml:
+//
+//	linters:
+//	  enable:
+//	    - dewey
+//	  settings:
+//	    custom:
+//	      dewey:
+//	        type: module
+//	        description: dewey static analyzers (defererr, seqerror, repool)
+//	        settings:
+//	          defererr: true
+//	          seqerror: true
+//	          repool: false
+//
+// All three analyzers are enabled by default; the settings block lets a
+// consumer opt out per analyzer. defererr and seqerror are general Go
+// checks; repool is purse-first-pool-specific and a no-op in packages
+// that do not import the pool ownership types.
+//
+// The analyzers' suppression comments (//defer:err-checked,
+// //seq:err-checked, //repool:owned, //repool:suppress) carry over
+// unchanged.
+package gclplugin
+
+import (
+	"github.com/golangci/plugin-module-register/register"
+	"golang.org/x/tools/go/analysis"
+
+	"github.com/amarbel-llc/purse-first/libs/dewey/pkgs/analyzer_defererr"
+	"github.com/amarbel-llc/purse-first/libs/dewey/pkgs/analyzer_repool"
+	"github.com/amarbel-llc/purse-first/libs/dewey/pkgs/analyzer_seqerror"
+)
+
+func init() {
+	register.Plugin("dewey", New)
+}
+
+// Settings selects which dewey analyzers the plugin contributes. A nil
+// pointer means "use the default" (enabled); an explicit false disables
+// that analyzer. The zero Settings value therefore enables all three.
+type Settings struct {
+	Defererr *bool `json:"defererr,omitempty"`
+	Seqerror *bool `json:"seqerror,omitempty"`
+	Repool   *bool `json:"repool,omitempty"`
+}
+
+// Plugin is the dewey golangci-lint module plugin.
+type Plugin struct {
+	settings Settings
+}
+
+// New is the plugin constructor registered with golangci-lint.
+func New(conf any) (register.LinterPlugin, error) {
+	settings, err := register.DecodeSettings[Settings](conf)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Plugin{settings: settings}, nil
+}
+
+// BuildAnalyzers returns the enabled dewey analyzers.
+func (p *Plugin) BuildAnalyzers() ([]*analysis.Analyzer, error) {
+	analyzers := make([]*analysis.Analyzer, 0, 3)
+
+	if enabled(p.settings.Defererr) {
+		analyzers = append(analyzers, analyzer_defererr.Analyzer)
+	}
+	if enabled(p.settings.Seqerror) {
+		analyzers = append(analyzers, analyzer_seqerror.Analyzer)
+	}
+	if enabled(p.settings.Repool) {
+		analyzers = append(analyzers, analyzer_repool.Analyzer)
+	}
+
+	return analyzers, nil
+}
+
+// GetLoadMode reports that the analyzers need full type information; all
+// three inspect go/types data.
+func (p *Plugin) GetLoadMode() string {
+	return register.LoadModeTypesInfo
+}
+
+// enabled reports whether an analyzer toggle is on. A nil pointer
+// defaults to enabled so the zero Settings value enables every analyzer.
+func enabled(b *bool) bool {
+	return b == nil || *b
+}

--- a/libs/dewey/gclplugin/plugin_test.go
+++ b/libs/dewey/gclplugin/plugin_test.go
@@ -1,0 +1,99 @@
+package gclplugin
+
+import (
+	"testing"
+
+	"github.com/golangci/plugin-module-register/register"
+)
+
+func ptr(b bool) *bool { return &b }
+
+func TestNewDefaultsToAllAnalyzers(t *testing.T) {
+	lp, err := New(nil)
+	if err != nil {
+		t.Fatalf("New(nil): %v", err)
+	}
+
+	analyzers, err := lp.BuildAnalyzers()
+	if err != nil {
+		t.Fatalf("BuildAnalyzers: %v", err)
+	}
+
+	if got, want := len(analyzers), 3; got != want {
+		t.Fatalf("default analyzer count = %d, want %d", got, want)
+	}
+
+	if got := lp.GetLoadMode(); got != register.LoadModeTypesInfo {
+		t.Fatalf("GetLoadMode() = %q, want %q", got, register.LoadModeTypesInfo)
+	}
+}
+
+func TestSettingsSelectAnalyzers(t *testing.T) {
+	cases := []struct {
+		name     string
+		settings map[string]any
+		want     []string
+	}{
+		{
+			name:     "repool disabled",
+			settings: map[string]any{"repool": false},
+			want:     []string{"defererr", "seqerror"},
+		},
+		{
+			name:     "only defererr",
+			settings: map[string]any{"defererr": true, "seqerror": false, "repool": false},
+			want:     []string{"defererr"},
+		},
+		{
+			name:     "all explicitly off",
+			settings: map[string]any{"defererr": false, "seqerror": false, "repool": false},
+			want:     nil,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			lp, err := New(tc.settings)
+			if err != nil {
+				t.Fatalf("New: %v", err)
+			}
+
+			analyzers, err := lp.BuildAnalyzers()
+			if err != nil {
+				t.Fatalf("BuildAnalyzers: %v", err)
+			}
+
+			got := make([]string, len(analyzers))
+			for i, a := range analyzers {
+				got[i] = a.Name
+			}
+
+			if len(got) != len(tc.want) {
+				t.Fatalf("analyzers = %v, want %v", got, tc.want)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Fatalf("analyzers = %v, want %v", got, tc.want)
+				}
+			}
+		})
+	}
+}
+
+func TestNewRejectsUnknownSettings(t *testing.T) {
+	if _, err := New(map[string]any{"bogus": true}); err == nil {
+		t.Fatal("New with unknown field: expected error, got nil")
+	}
+}
+
+func TestEnabledHelper(t *testing.T) {
+	if !enabled(nil) {
+		t.Fatal("enabled(nil) = false, want true")
+	}
+	if enabled(ptr(false)) {
+		t.Fatal("enabled(false) = true, want false")
+	}
+	if !enabled(ptr(true)) {
+		t.Fatal("enabled(true) = false, want true")
+	}
+}

--- a/libs/dewey/go.mod
+++ b/libs/dewey/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/charmbracelet/x/xpty v0.1.3
 	github.com/dave/jennifer v1.7.1
+	github.com/golangci/plugin-module-register v0.1.2
 	github.com/google/go-cmp v0.7.0
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/tonistiigi/vt100 v0.0.0-20240514184818-90bafcd6abab

--- a/libs/dewey/go.sum
+++ b/libs/dewey/go.sum
@@ -19,6 +19,7 @@ github.com/charmbracelet/bubbletea v1.3.10/go.mod h1:ORQfo0fk8U+po9VaNvnV95UPWA1
 github.com/charmbracelet/colorprofile v0.4.1 h1:a1lO03qTrSIRaK8c3JRxJDZOvhvIeSco3ej+ngLk1kk=
 github.com/charmbracelet/colorprofile v0.4.1/go.mod h1:U1d9Dljmdf9DLegaJ0nGZNJvoXAhayhmidOdcBwAvKk=
 github.com/charmbracelet/harmonica v0.2.0 h1:8NxJWRWg/bzKqqEaaeFNipOu77YR5t8aSwG4pgaUBiQ=
+github.com/charmbracelet/harmonica v0.2.0/go.mod h1:KSri/1RMQOZLbw7AHqgcBycp8pgJnQMYYT8QZRqZ1Ao=
 github.com/charmbracelet/lipgloss v1.1.0 h1:vYXsiLHVkK7fp74RkV7b2kq9+zDLoEU4MZoFqR/noCY=
 github.com/charmbracelet/lipgloss v1.1.0/go.mod h1:/6Q8FR2o+kj8rz4Dq0zQc3vYf7X+B0binUUBwA0aL30=
 github.com/charmbracelet/x/ansi v0.11.6 h1:GhV21SiDz/45W9AnV2R61xZMRri5NlLnl6CVF7ihZW8=
@@ -36,8 +37,11 @@ github.com/charmbracelet/x/termios v0.1.1/go.mod h1:rB7fnv1TgOPOyyKRJ9o+AsTU/vK5
 github.com/charmbracelet/x/xpty v0.1.3 h1:eGSitii4suhzrISYH50ZfufV3v085BXQwIytcOdFSsw=
 github.com/charmbracelet/x/xpty v0.1.3/go.mod h1:poPYpWuLDBFCKmKLDnhBp51ATa0ooD8FhypRwEFtH3Y=
 github.com/clipperhouse/displaywidth v0.9.0 h1:Qb4KOhYwRiN3viMv1v/3cTBlz3AcAZX3+y9OLhMtAtA=
+github.com/clipperhouse/displaywidth v0.9.0/go.mod h1:aCAAqTlh4GIVkhQnJpbL0T/WfcrJXHcj8C0yjYcjOZA=
 github.com/clipperhouse/stringish v0.1.1 h1:+NSqMOr3GR6k1FdRhhnXrLfztGzuG+VuFDfatpWHKCs=
+github.com/clipperhouse/stringish v0.1.1/go.mod h1:v/WhFtE1q0ovMta2+m+UbpZ+2/HEXNWYXQgCt4hdOzA=
 github.com/clipperhouse/uax29/v2 v2.5.0 h1:x7T0T4eTHDONxFJsL94uKNKPHrclyFI0lm7+w94cO8U=
+github.com/clipperhouse/uax29/v2 v2.5.0/go.mod h1:Wn1g7MK6OoeDT0vL+Q0SQLDz/KpfsVRgg6W7ihQeh4g=
 github.com/creack/pty v1.1.24 h1:bJrF4RRfyJnbTJqzRLHzcGaZK1NeM5kTC9jGgovnR1s=
 github.com/creack/pty v1.1.24/go.mod h1:08sCNb52WyoAwi2QDyzUCTgcvVFhUzewun7wtTfvcwE=
 github.com/dave/jennifer v1.7.1 h1:B4jJJDHelWcDhlRQxWeo0Npa/pYKBLrirAQoTN45txo=
@@ -48,6 +52,8 @@ github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f h1:Y/CXytFA4m6
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f/go.mod h1:vw97MGsxSvLiUE2X8qFplwetxpGLQrlU1Q9AUEIzCaM=
 github.com/go-quicktest/qt v1.101.0 h1:O1K29Txy5P2OK0dGo59b7b0LR6wKfIhttaAhHUyn7eI=
 github.com/go-quicktest/qt v1.101.0/go.mod h1:14Bz/f7NwaXPtdYEgzsx46kqSxVwTbzVZsDC26tQJow=
+github.com/golangci/plugin-module-register v0.1.2 h1:e5WM6PO6NIAEcij3B053CohVp3HIYbzSuP53UAYgOpg=
+github.com/golangci/plugin-module-register v0.1.2/go.mod h1:1+QGTsKBvAIvPvoY/os+G5eoqxWn70HYDm2uvUyGuVw=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=


### PR DESCRIPTION
Add libs/dewey/gclplugin, a golangci-lint Module Plugin System
registration that surfaces the three dewey go/analysis analyzers
(defererr, seqerror, repool) under a single "dewey" linter. Downstream
repos that already gate on golangci-lint can now fold these checks into
that run instead of a separate `go vet -vettool` pass.

The plugin imports the stable pkgs/analyzer_<name> facades and calls
register.Plugin("dewey", New). Settings lets consumers opt out per
analyzer (all enabled by default; repool is a no-op outside pool-owning
packages). Suppression comments carry over unchanged. The cmd/<name>
singlechecker + vettool path is untouched; this is purely additive.

Closes #120.